### PR TITLE
Adding COBS conda env

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -203,6 +203,7 @@ rule run_cobs:
     params:
         kmer_thres=config["cobs_kmer_thres"],
     priority: 999
+    conda: "envs/cobs.yaml"
     shell:
         """
         cobs query \\
@@ -226,6 +227,7 @@ rule decompress_and_run_cobs:
     params:
         kmer_thres=config["cobs_kmer_thres"],
         decompression_dir=decompression_dir
+    conda: "envs/cobs.yaml"
     shell:
         """
         mkdir -p {params.decompression_dir}

--- a/envs/cobs.yaml
+++ b/envs/cobs.yaml
@@ -1,0 +1,4 @@
+channels:
+ - bioconda
+dependencies:
+ - cobs=0.2.0


### PR DESCRIPTION
`cobs 0.2.0` is now available in bioconda. This PR adds the COBS conda env and uses it in COBS rules.

Closes https://github.com/karel-brinda/mof-search/issues/51
Closes https://github.com/karel-brinda/mof-search/issues/47
Closes https://github.com/karel-brinda/mof-search/issues/41
Closes https://github.com/karel-brinda/mof-search/issues/39