### PR TITLE
Removing COBS from dependencies in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,13 +5,6 @@ This is the pipeline for BLAST-like search within the 661k collection.
 
 ## Dependencies
 
-:warning: **`Mac OS X` users have to necessarily install `gcc-11` to run `mof-search`. The easiest way is through `brew`:**
-```
-brew install gcc@11
-```
-
-
-
 Some dependencies are packaged into `conda` environments that `snakemake` will automatically create.
 Others are non-standard (which you might need to install) and standard (which you probably have).
 


### PR DESCRIPTION
Forgot to do this in the COBS conda PR