### PR TITLE
Adding max_decomp_jobs resource to COBS rule

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -254,6 +254,8 @@ rule decompress_and_run_cobs:
     input:
         compressed_cobs_index=f"{cobs_dir}/{{batch}}.cobs_classic.xz",
         fa="intermediate/concatenated_query/{qfile}.fa",
+    resources:
+        max_decomp_jobs=1,
     threads: config["cobs_thr"]  # Small number in order to guarantee Snakemake parallelization
     params:
         kmer_thres=config["cobs_kmer_thres"],


### PR DESCRIPTION
To make rule `decompress_and_run_cobs` respect `max_decomp_jobs` resource