### PR TITLE
Load balance `decompress_cobs` and `decompress_and_run_cobs` rules based on input size instead of job count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ SHELL=/usr/bin/env bash -eo pipefail
 
 .SUFFIXES:
 
-MAX_DECOMP_JOBS=$(shell grep "^max_decomp_jobs" config.yaml | awk '{print $$2}')
+MAX_DECOMP_MB=$(shell grep "^max_decomp_MB" config.yaml | awk '{print $$2}')
 MAX_DOWNLOAD_JOBS=$(shell grep "^max_download_jobs" config.yaml | awk '{print $$2}')
 THR=$(shell grep "^thr" config.yaml | awk '{print $$2}')
-SMK_PARAMS=--jobs ${THR} --rerun-incomplete --printshellcmds --keep-going --use-conda --resources max_decomp_jobs=$(MAX_DECOMP_JOBS) max_download_jobs=$(MAX_DOWNLOAD_JOBS)
+SMK_PARAMS=--jobs ${THR} --rerun-incomplete --printshellcmds --keep-going --use-conda --resources max_decomp_MB=$(MAX_DECOMP_MB) max_download_jobs=$(MAX_DOWNLOAD_JOBS)
 
 all: ## Run everything
 	snakemake $(SMK_PARAMS)

--- a/Snakefile
+++ b/Snakefile
@@ -205,7 +205,7 @@ rule decompress_cobs:
     input:
         xz=f"{cobs_dir}/{{batch}}.cobs_classic.xz",
     resources:
-        max_decomp_jobs=1,
+        max_decomp_MB=lambda wildcards, input: input.xz.size//1_000_000 + 1
     threads: config["cobs_thr"]  # The same number as of COBS threads to ensure that COBS is executed immediately after decompression
     params:
         benchmark_flag = benchmark_flag,
@@ -255,7 +255,7 @@ rule decompress_and_run_cobs:
         compressed_cobs_index=f"{cobs_dir}/{{batch}}.cobs_classic.xz",
         fa="intermediate/concatenated_query/{qfile}.fa",
     resources:
-        max_decomp_jobs=1,
+        max_decomp_MB=lambda wildcards, input: input.compressed_cobs_index.size//1_000_000 + 1
     threads: config["cobs_thr"]  # Small number in order to guarantee Snakemake parallelization
     params:
         kmer_thres=config["cobs_kmer_thres"],

--- a/config.yaml
+++ b/config.yaml
@@ -7,8 +7,6 @@
 thr: all
 # batches to consider during search
 batches: "batches_full.txt"
-# maximum number of xz-decompression jobs at a single time (note: too many might slow down the filesystem)
-max_decomp_jobs: 4
 # maximum number of download jobs at a time (note: too many might slow down download speed)
 max_download_jobs: 8
 ##################################################
@@ -36,6 +34,12 @@ minimap_extra_params: "--eqx"
 
 ###################################################################################################
 # filesystem configuration
+
+# maximum number of xz-compressed MB to process simultaneously. This is used to balance the xz-decompression when
+# running the pipeline. For the 661k data, the heaviest xz-compressed COBS index has 1434MB, while the lightest have
+# on the order of few MBs. Setting this value to 2000 for the 661k allows us to run heaviest decompressions mixed
+# with light ones in order to improve performance (note: setting this value too high might slow down the filesystem)
+max_decomp_MB: 2000
 
 # keep or not decompressed COBS index. If kept, can speed up subsequent searches but will take much more disk
 # space, as the decompressed indexes won't be cleaned up.


### PR DESCRIPTION
This PR balances the load of  `decompress_cobs` and `decompress_and_run_cobs` jobs based on the size of the indexes being processed instead of the sheer number of jobs, so that we can mix heavy and light decompression/COBS jobs, improving throughput. By doing this, the pipeline ran `COBS` with at most one heavy (e.g. dustbin) index mixed with other light indexes.  For more details, see #92 

The default params basically say we can process at most 2000 MB of input xz-compressed index at a time. By using this param, the `match` process for `ARGannot_r3.nonamb` decreased from ~5.9h to ~2.75h on my Linux machine, i.e. a 53% reduction in time (CPU usage from 35% to 76%), so I think it is worth to do this load balancing based on the index size. Of course, this threshold of 2000 MB depends a lot on the filesystem speed. Could you also try on your machine and see how faster you get?

The `max_decomp_MB` could potentially be set automatically as the heaviest index size plus some padding (e.g. `1.25 * size_of_heaviest_index`), thus effectively enabling us to process the heavy indexes with some light ones.

Close #92 