### PR TITLE
Adding `max_heavy_IO_jobs` to `config.yaml`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,10 @@ DATETIME=$(shell date -u +"%Y_%m_%dT%H_%M_%S")
 .SUFFIXES:
 
 MAX_DECOMP_MB=$(shell grep "^max_decomp_MB" config.yaml | awk '{print $$2}')
+MAX_HEAVY_IO_JOBS=$(shell grep "^max_heavy_IO_jobs" config.yaml | awk '{print $$2}')
 MAX_DOWNLOAD_JOBS=$(shell grep "^max_download_jobs" config.yaml | awk '{print $$2}')
 THR=$(shell grep "^thr" config.yaml | awk '{print $$2}')
-SMK_PARAMS=--jobs ${THR} --rerun-incomplete --printshellcmds --keep-going --use-conda --resources max_decomp_MB=$(MAX_DECOMP_MB) max_download_jobs=$(MAX_DOWNLOAD_JOBS)
+SMK_PARAMS=--jobs ${THR} --rerun-incomplete --printshellcmds --keep-going --use-conda --resources max_decomp_MB=$(MAX_DECOMP_MB) max_download_jobs=$(MAX_DOWNLOAD_JOBS) max_heavy_IO_jobs=$(MAX_HEAVY_IO_JOBS)
 
 all: ## Run everything
 	snakemake $(SMK_PARAMS)

--- a/Snakefile
+++ b/Snakefile
@@ -205,7 +205,8 @@ rule decompress_cobs:
     input:
         xz=f"{cobs_dir}/{{batch}}.cobs_classic.xz",
     resources:
-        max_decomp_MB=lambda wildcards, input: input.xz.size//1_000_000 + 1
+        max_decomp_MB=lambda wildcards, input: input.xz.size//1_000_000 + 1,
+        max_heavy_IO_jobs=1,
     threads: config["cobs_thr"]  # The same number as of COBS threads to ensure that COBS is executed immediately after decompression
     params:
         benchmark_flag = benchmark_flag,
@@ -226,6 +227,8 @@ rule run_cobs:
         cobs_index=f"{decompression_dir}/{{batch}}.cobs_classic",
         fa="intermediate/concatenated_query/{qfile}.fa",
     threads: config["cobs_thr"]  # Small number in order to guarantee Snakemake parallelization
+    resources:
+        max_heavy_IO_jobs=1,
     params:
         kmer_thres=config["cobs_kmer_thres"],
         benchmark_flag= benchmark_flag,
@@ -255,7 +258,8 @@ rule decompress_and_run_cobs:
         compressed_cobs_index=f"{cobs_dir}/{{batch}}.cobs_classic.xz",
         fa="intermediate/concatenated_query/{qfile}.fa",
     resources:
-        max_decomp_MB=lambda wildcards, input: input.compressed_cobs_index.size//1_000_000 + 1
+        max_decomp_MB=lambda wildcards, input: input.compressed_cobs_index.size//1_000_000 + 1,
+        max_heavy_IO_jobs=1,
     threads: config["cobs_thr"]  # Small number in order to guarantee Snakemake parallelization
     params:
         kmer_thres=config["cobs_kmer_thres"],

--- a/config.yaml
+++ b/config.yaml
@@ -36,10 +36,14 @@ minimap_extra_params: "--eqx"
 # filesystem configuration
 
 # maximum number of xz-compressed MB to process simultaneously. This is used to balance the xz-decompression when
-# running the pipeline. For the 661k data, the heaviest xz-compressed COBS index has 1434MB, while the lightest have
+# running the pipeline. For the 661k data, the heaviest xz-compressed COBS index has 1434MB, while the lightests have
 # on the order of few MBs. Setting this value to 2000 for the 661k allows us to run heaviest decompressions mixed
 # with light ones in order to improve performance (note: setting this value too high might slow down the filesystem)
 max_decomp_MB: 2000
+
+# maximum number of heavy I/O jobs (for xz decompression and COBS). This is used in conjunction with max_decomp_MB to
+# not overflow the filesystem I/O
+max_heavy_IO_jobs: 4
 
 # keep or not decompressed COBS index. If kept, can speed up subsequent searches but will take much more disk
 # space, as the decompressed indexes won't be cleaned up.


### PR DESCRIPTION
Controls how many `decompress_cobs`, `run_cobs` and `decompress_and_run_cobs` jobs are run simultaneously. Just like the old `decomp_thr` parameter

Closes #99 
Closes #100