### PR TITLE
Use files created in `/tmp` for `minimap2` references and improves pipe code

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -56,12 +56,8 @@ wildcard_constraints:
 
 
 if config["keep_cobs_ind"]:
-
     ruleorder: decompress_cobs > run_cobs > decompress_and_run_cobs
-
-
 else:
-
     ruleorder: decompress_and_run_cobs > decompress_cobs > run_cobs
 
 
@@ -323,6 +319,7 @@ rule batch_align_minimap2:
         minimap_threads=config["minimap_thr"],
         minimap_extra_params=config["minimap_extra_params"],
         benchmark_flag = benchmark_flag,
+        pipe = "--pipe" if config["prefer_pipe"] else ""
     conda:
         "envs/minimap2.yaml"
     threads: config["minimap_thr"]
@@ -334,6 +331,7 @@ rule batch_align_minimap2:
                 --minimap-preset {params.minimap_preset} \\
                 --threads {params.minimap_threads} \\
                 --extra-params=\"{params.minimap_extra_params}\" \\
+                {params.pipe} \\
                 {input.asm} \\
                 {input.qfa} \\
                 > {output.sam} 2>{log}'

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,8 @@ minimap_preset: "sr"
 minimap_thr: 1
 # other minimap2 params
 minimap_extra_params: "--eqx"
+# prefer use pipe or not when running minimap (note: keep this False unless you have a slow filesystem)
+prefer_pipe: False
 ##################################################
 
 ###################################################################################################


### PR DESCRIPTION
Main things in this PR:

1. Added a parameter in `config.yaml` to tell the pipeline to use pipe or (temporary) files for references when running `minimap2`:
```
# prefer use pipe or not when running minimap (note: keep this False unless you have a slow filesystem)
prefer_pipe: False
```
In `linux` using files resulted in much faster `map` speed (~4.3x faster in sample example, `ARGannot_r3` benchmark mapping done in 50 mins). This is because in `linux` `/tmp` is a RAM disk and we don't need to synchronise read and writes, like we have to do for pipes. As a plus, we don't have any issues with `minimap2` jobs stuck at all. Due to this, I am setting `prefer_pipe` as `False` by default, i.e. by default we use files in `/tmp`. I am not sure if this is true for `darwin`. @karel-brinda could you please try and report if using files you get faster mapping speed too? Details about the benchmarking I've done can be found here: https://github.com/karel-brinda/mof-search/issues/109#issuecomment-1214338372

2. Improved pipe code:
2.1. Lots of debug messages in the pipe code to try to debug issues with named pipes if needed;
2.2. Increased default pipe buffer size;
2.3. Using `select()` to wait for the pipe to be ready to be written to;
2.4. Wait for `minimap2` to start before writing data to pipe;
2.5. Timing out in 5 seconds if minimap2 does not finish, and running minimap2 with disk as backup;
 
Although there was a lot of effort devoted to improve our usage of named pipes, using temp files is simply much easier to implement and has much better performance. In `linux` this should be the default. I will wait for your tests to check if it should also be the default for `darwin`.