### PR TITLE
Now also catching subprocess.TimeoutExpired

### DIFF
--- a/scripts/batch_align.py
+++ b/scripts/batch_align.py
@@ -260,7 +260,7 @@ def minimap_wrapper(rfa, qfa, minimap_preset, minimap_threads,
         try:
             return minimap2_4(rfa, qfa, minimap_preset, minimap_threads,
                               minimap_extra_params)
-        except concurrent.futures.TimeoutError:
+        except (concurrent.futures.TimeoutError, subprocess.TimeoutExpired):
             logging.warning("Minimap2 timed out, using disk")
             return minimap2_using_disk(rfa, qfa, minimap_preset,
                                        minimap_threads, minimap_extra_params)


### PR DESCRIPTION
Tries to fix https://github.com/karel-brinda/mof-search/issues/123 , but I think I can't reproduce (I get `concurrent.futures.TimeoutError` exception instead), so you will have to test to see if this fixes the issue...