### PR TITLE
Add the wallclock elapsed time to the time logging

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -43,7 +43,8 @@ def main():
         log_file.parent.mkdir(parents=True, exist_ok=True)
         tmp_log_file = Path(f"{log_file}.tmp")
         with open(log_file, "w") as log_fh:
-            print(f"# Benchmarking command: {args.command}", file=log_fh)
+            formatted_command = " ".join(args.command.replace("\\\n", " ").strip().split())
+            print(f"# Benchmarking command: {formatted_command}", file=log_fh)
             header = [
                 "real(s)", "sys(s)", "user(s)", "percent_CPU", "max_RAM(kb)",
                 "FS_inputs", "FS_outputs", "elapsed_time_alt(s)"


### PR DESCRIPTION
This does  not fix the correctness of time logging reported in https://github.com/karel-brinda/mof-search/issues/130 but it additionally reports the wallclock elapsed time so that we have a less detailed but reliable time measurement