### PR TITLE
Drop fasta comments from COBS output AND drop reads matching 0 refs

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -248,6 +248,7 @@ rule run_cobs:
                 -T {threads} \\
                 -i {input.cobs_index} \\
                 -f {input.fa} \\
+            | awk \\'{if(substr($1,1,1)=="*"){ if($NF>0){ print $1, $NF } } else{ print $0 } }\\' \\
             | xz -v \\
             > {output.match}'
         """
@@ -288,6 +289,7 @@ rule decompress_and_run_cobs:
                 -T {threads} \\
                 -i "{params.cobs_index}" \\
                 -f {input.fa} \\
+            | awk '"'"'{{if(substr($1,1,1)=="*"){{ if($NF>0){{ print $1, $NF }} }} else{{ print $0 }} }}'"'"' \\
             | xz -v \\
             > {output.match}'
 

--- a/scripts/filter_queries.py
+++ b/scripts/filter_queries.py
@@ -55,8 +55,8 @@ def cobs_iterator(cobs_matches_fn):
                     yield qname, batch, matches_buffer
                     matches_buffer = []
                 # parse header
-                parts = x[1:].split("\t")
-                qname = parts[0].split(" ")[0]  # remove fasta comments
+                parts = x[1:].split()
+                qname = parts[0]
                 nmatches = int(parts[1])
             else:
                 ## MATCH


### PR DESCRIPTION
Fix #152 