### PR TITLE
Remove random identifiers from cobs output before storing on disk

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -248,7 +248,7 @@ rule run_cobs:
                     -T {threads} \\
                     -i {input.cobs_index} \\
                     -f {input.fa} \\
-                | perl -pe 's/^(?!\*).*_/_/g' \\
+                | perl -pe "s/^(?!\*).*_/_/g" \\
                 | xz -v -T {threads} \\
                 > {output.match}'
         """
@@ -289,7 +289,7 @@ rule decompress_and_run_cobs:
                     -T {threads} \\
                     -i "{params.cobs_index}" \\
                     -f {input.fa} \\
-                | perl -pe 's/^(?!\*).*_/_/g' \\
+                | perl -pe "s/^(?!\*).*_/_/g" \\
                 | xz -v -T {threads} \\
                 > {output.match}'
 


### PR DESCRIPTION
closes #147