### PR TITLE
Fixes make test fails in Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test: ## Run everything but just with 3 batches to test full pipeline
 	snakemake $(SMK_PARAMS) -j 99999 --config batches=data/batches_small.txt -- download  # download is not benchmarked
 	scripts/benchmark.py --log logs/benchmarks/test_match_$(DATETIME).txt "snakemake $(SMK_PARAMS) --config batches=data/batches_small.txt nb_best_hits=1 -- match"
 	scripts/benchmark.py --log logs/benchmarks/test_map_$(DATETIME).txt   "snakemake $(SMK_PARAMS) --config batches=data/batches_small.txt nb_best_hits=1 -- map"
-	diff -qs <(xzcat output/reads_1___reads_2___reads_3___reads_4.sam_summary.xz | cut -f -3) <(xzcat data/reads_1___reads_2___reads_3___reads_4.sam_summary.xz  | cut -f -3)
+	diff -s <(xzcat output/reads_1___reads_2___reads_3___reads_4.sam_summary.xz | cut -f -3) <(xzcat data/reads_1___reads_2___reads_3___reads_4.sam_summary.xz  | cut -f -3)
 
 download: ## Download the 661k assemblies and COBS indexes, not benchmarked
 	snakemake $(SMK_PARAMS) -j 99999 -- download


### PR DESCRIPTION
After running the test pipeline, we now just compare the query, reference and SAM flag fields. I think these are the 3 most important fields in a SAM file. Closes #167 