### PR TITLE
Measuring pipeline's RAM usage with another method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ Others are non-standard (which you might need to install) and standard (which yo
 * `python >= 3.7`
 * `snakemake >= 6.2.0`
 * `mamba >= 0.20.0`
+* `psutil`
 
 If you want to benchmark the pipeline and is on `Mac OS X`, you need to install `gnu-time`:
 ```

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -29,8 +29,6 @@ def main():
     log_file = Path(args.log)
     log_file.parent.mkdir(parents=True, exist_ok=True)
     tmp_log_file = Path(f"{log_file}.tmp")
-
-    # TODO: this would be done better with a decorator, would avoid the two ifs
     is_benchmarking_pipeline = args.command.split()[0] == "snakemake"
 
     with open(log_file, "w") as log_fh:
@@ -40,30 +38,38 @@ def main():
             "real(s)", "sys(s)", "user(s)", "percent_CPU", "max_RAM(kb)", "FS_inputs", "FS_outputs",
             "elapsed_time_alt(s)"
         ]
+        if is_benchmarking_pipeline:
+            header.append("max_delta_system_RAM(kb)")
         print("\t".join(header), file=log_fh)
 
     time_command = get_time_command()
     benchmark_command = f'{time_command} -o {tmp_log_file} -f "%e\t%S\t%U\t%P\t%M\t%I\t%O"'
 
+    start_time = datetime.datetime.now()
+    main_process = subprocess.Popen(f'{benchmark_command} {args.command}', shell=True)
     if is_benchmarking_pipeline:
         RAM_tmp_log_file = Path(f"{log_file}.RAM.tmp")
-        RAM_benchmarking_process = subprocess.Popen(["python", "scripts/get_RAM_usage.py", str(RAM_tmp_log_file)])
+        RAM_benchmarking_process = subprocess.Popen([sys.executable, "scripts/get_RAM_usage.py", str(RAM_tmp_log_file),
+                                                     str(main_process.pid)])
+    return_code = main_process.wait()
+    if return_code:
+        raise subprocess.CalledProcessError(return_code, main_process.args,
+                                 output=main_process.stdout, stderr=main_process.stderr)
 
-    start_time = datetime.datetime.now()
-    subprocess.check_call(f'{benchmark_command} {args.command}', shell=True)
     end_time = datetime.datetime.now()
     elapsed_seconds = (end_time - start_time).total_seconds()
     with open(tmp_log_file) as log_fh_tmp, open(log_file, "a") as log_fh:
         log_line = log_fh_tmp.readline().strip()
         log_line += f"\t{elapsed_seconds}"
-        print(log_line, file=log_fh)
 
-    if is_benchmarking_pipeline:
-        RAM_benchmarking_process.kill()
-        with open(RAM_tmp_log_file) as log_fh_tmp, open(log_file, "a") as log_fh:
-            print("RAM usage:", file=log_fh)
-            print("\n".join(map(str.strip, log_fh_tmp.readlines())), file=log_fh)
-        RAM_tmp_log_file.unlink()
+        if is_benchmarking_pipeline:
+            RAM_benchmarking_process.kill()
+            with open(RAM_tmp_log_file) as RAM_tmp_log_fh:
+                RAM_usage = RAM_tmp_log_fh.readline().strip()
+            log_line += f"\t{RAM_usage}"
+            RAM_tmp_log_file.unlink()
+
+        print(log_line, file=log_fh)
 
     tmp_log_file.unlink()
 

--- a/scripts/get_RAM_usage.py
+++ b/scripts/get_RAM_usage.py
@@ -1,7 +1,7 @@
-import os
 import time
 import sys
 from pathlib import Path
+import psutil
 
 log_file = Path(sys.argv[1])
 log_file.parent.mkdir(parents=True, exist_ok=True)
@@ -9,14 +9,12 @@ log_file.parent.mkdir(parents=True, exist_ok=True)
 initial_RAM = None
 max_RAM_usage = 0
 while True:
-    RAM_usage = int(os.popen('free --bytes').readlines()[1].split()[2])
-    RAM_usage = RAM_usage / 1024 / 1024 / 1024
+    RAM_usage = psutil.virtual_memory().used
+    RAM_usage = RAM_usage / 1024
     max_RAM_usage = max(max_RAM_usage, RAM_usage)
     if initial_RAM is None:
         initial_RAM = RAM_usage
     mof_search_RAM_usage = max_RAM_usage - initial_RAM
     with open(log_file, "w", buffering=1024) as fout:
-        fout.write(f"Initial RAM usage (GB): {initial_RAM:.2f}\n")
-        fout.write(f"Max RAM usage (GB): {max_RAM_usage:.2f}\n")
-        fout.write(f"mof-search predicted RAM usage (GB): {mof_search_RAM_usage:.2f}\n")
-    time.sleep(0.5)
+        fout.write(f"{mof_search_RAM_usage:.2f}")
+    time.sleep(0.1)


### PR DESCRIPTION
This PR adds code to watch the system's memory instead of trying to get the RAM usage from the pipeline process itself. The bad thing about this implementation is that to get precise measurements, we should not run anything else together with the pipeline. In my machine, I got better measurements with this method with small test data. Running on my benchmarking machine for the EBI plasmids query, the difference was not big, but my config was not ideal to test it, because the highest COBS job takes 10.35 GB of RAM (this is what the old method reports), but my RAM limit for the pipeline was 12 GB, so there is not much room to use more RAM. Anyway, this new RAM measurement is appended to the pipeline benchmark logs upon running it. For example this is what I have for the match and map steps now for EBI plasmids:

### match

old method: 10.35 GB
new method: 11.24 GB

```
cat match_2022_12_06T12_45_03.txt 
# Benchmarking command: snakemake --jobs all --rerun-incomplete --printshellcmds --keep-going --use-conda --resources max_download_threads=8 max_io_heavy_threads=8 max_ram_mb=12288 -- match
real(s)	sys(s)	user(s)	percent_CPU	max_RAM(kb)	FS_inputs	FS_outputs	elapsed_time_alt(s)
28356.15	1601.52	132002.67	471%	10854992	143254656	1516440	28356.171665
RAM usage:
Initial RAM usage (GB): 0.55
Max RAM usage (GB): 11.80
mof-search predicted RAM usage (GB): 11.24
```

### map

old method: 0.84 GB
new method: 2.82 GB

```
cat map_2022_12_06T20_37_39.txt 
# Benchmarking command: snakemake --jobs all --rerun-incomplete --printshellcmds --keep-going --use-conda --resources max_download_threads=8 max_io_heavy_threads=8 max_ram_mb=12288 -- map
real(s)	sys(s)	user(s)	percent_CPU	max_RAM(kb)	FS_inputs	FS_outputs	elapsed_time_alt(s)
5309.85	2339.90	24025.16	496%	882980	67777896	14248400	5309.870436
RAM usage:
Initial RAM usage (GB): 0.54
Max RAM usage (GB): 3.37
mof-search predicted RAM usage (GB): 2.82
```

I am curious what you will get in your machine with the same configs given here: https://github.com/karel-brinda/mof-search/issues/219