### PR TITLE
fix: fewer concurrent downloads so that Zenodo does not start blocking downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ conda: ## Create the conda environments
 	snakemake $(SMK_PARAMS) --conda-create-envs-only
 
 download: ## Download the assemblies and COBS indexes
-	snakemake download $(SMK_PARAMS) -j 99999
+	snakemake download $(SMK_PARAMS) --restart-times 3 -j 99999
 
 match: ## Match queries using COBS (queries -> candidates)
 	scripts/benchmark.py --log logs/benchmarks/match_$(DATETIME).txt "snakemake match $(SMK_PARAMS)"

--- a/config.yaml
+++ b/config.yaml
@@ -59,7 +59,7 @@ max_ram_gb: 12
 
 # maximum number of download threads at a time (note: too many might slow down download speed)
 # WARNING: this parameter is ignored when running on a cluster
-max_download_threads: 8
+max_download_threads: 4
 ##################################################
 
 ##################################################


### PR DESCRIPTION
This PR reduces the default value of `max_download_threads` from 8 to 4, and to add `--restart-times 3` when running `snakemake` in `make download`. The idea is to have fewer concurrent downloads so that Zenodo does not start blocking downloads. See more details in https://github.com/karel-brinda/mof-search/issues/236 .

Closes https://github.com/karel-brinda/mof-search/issues/236