### PR TITLE
Fix/236 (fix Zenodo blocking downloads)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ DATETIME=$(shell date -u +"%Y_%m_%dT%H_%M_%S")
 
 THREADS=$(shell grep "^threads:" config.yaml | awk '{print $$2}')
 MAX_DOWNLOAD_THREADS=$(shell grep "^max_download_threads" config.yaml | awk '{print $$2}')
+DOWNLOAD_RETRIES=$(shell grep "^download_retries" config.yaml | awk '{print $$2}')
 MAX_IO_HEAVY_THREADS=$(shell grep "^max_io_heavy_threads" config.yaml | awk '{print $$2}')
 MAX_RAM_MB=$(shell grep "^max_ram_gb:" config.yaml | awk '{print $$2*1024}')
 
@@ -69,7 +70,7 @@ conda: ## Create the conda environments
 	snakemake $(SMK_PARAMS) --conda-create-envs-only
 
 download: ## Download the assemblies and COBS indexes
-	snakemake download $(SMK_PARAMS) -j 99999 --restart-times 3
+	snakemake download $(SMK_PARAMS) -j 99999 --restart-times $(DOWNLOAD_RETRIES)
 
 download_asms: ## Download only the assemblies
 	snakemake download_asms_batches $(SMK_PARAMS) -j 99999

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ conda: ## Create the conda environments
 	snakemake $(SMK_PARAMS) --conda-create-envs-only
 
 download: ## Download the assemblies and COBS indexes
-	snakemake download $(SMK_PARAMS) -j 99999
+	snakemake download $(SMK_PARAMS) -j 99999 --restart-times 3
 
 download_asms: ## Download only the assemblies
 	snakemake download_asms_batches $(SMK_PARAMS) -j 99999

--- a/Snakefile
+++ b/Snakefile
@@ -206,7 +206,7 @@ def asms_url_fct(wildcards):
     return asm_url
 
 def get_sleep_amount(attempt):
-    return int(config["sleep_amount"]) * (attempt - 1)
+    return int(config["download_retry_wait"]) * (attempt - 1)
 
 ##################################
 ## Top-level rules

--- a/Snakefile
+++ b/Snakefile
@@ -206,10 +206,7 @@ def asms_url_fct(wildcards):
     return asm_url
 
 def get_sleep_amount(attempt):
-    if attempt == 1:
-        return 0
-    else:
-        return random.randint(0, (attempt-1)*60)  # adds a random sleep time between 0 and (attempt-1) minutes
+    return int(config["sleep_amount"]) * (attempt - 1)
 
 ##################################
 ## Top-level rules

--- a/config.yaml
+++ b/config.yaml
@@ -56,10 +56,25 @@ threads: all
 # if index_load_mode == mmap-disk, then this parameter is ignored as the OS will manage RAM usage
 # WARNING: this parameter is ignored when running on a cluster
 max_ram_gb: 12
+##################################################
 
-# maximum number of download threads at a time (note: too many might slow down download speed)
+##################################################
+# download
+
+# maximum number of download threads at a time (note: too many might slow down download speed and make Zenodo block your requests)
 # WARNING: this parameter is ignored when running on a cluster
 max_download_threads: 8
+
+# how many times to retry a download if it fails
+download_retries: 3
+
+# how many seconds to wait between retries
+download_retry_wait: 10
+
+# directory to store all downloaded files. This is where an "asms" folder with all assemblies and a "cobs" folder
+# with all COBS indexes will be created. This is a heavy directory, put it in a filesystem that has at least
+# 100 GB free
+download_dir: "."
 ##################################################
 
 ##################################################
@@ -121,9 +136,4 @@ keep_cobs_indexes: False
 # directory to store the COBS decompressed indexes. Can be used to put the decompressed indexes in an external
 # or large filesystem capable of holding them. If not defined, defaults to "intermediate/00_cobs"
 # decompression_dir: cobs_decompressed_indexes
-
-# directory to store all downloaded files. This is where an "asms" folder with all assemblies and a "cobs" folder
-# with all COBS indexes will be created. This is a heavy directory, put it in a filesystem that has at least
-# 100 GB free
-download_dir: "."
 ###################################################################################################

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+url=$1
+output=$2
+sleep_amount=$3
+
+if [ $sleep_amount -gt 0 ]; then
+    echo "Detected previous failed downloads, probably Zenodo blocking downloads."
+    echo "Now random sleeping for $sleep_amount seconds before retrying..."
+    sleep $sleep_amount
+    echo "Retrying..."
+fi
+echo "Downloading $url ..."
+curl -s -L "${url}"  > "${output}"
+scripts/test_xz.py "${output}"


### PR DESCRIPTION
The main change in this PR is dealing with Zenodo blocking downloads (see #236 for details). This is solved by adding a random sleep time between 0 and (attempt-1) minutes (or 0 and (attempt-1)*60 seconds) and retrying the download for up to 3 times.
Two tests in the EBI cluster succeeded, where Zenodo always blocks downloads after some time. In the first test, Zenodo blocked 85 downloads but the retries were successful. In the second test, 71 downloads were blocked but the retries were also successful. As such I think this PR solves this issue and closes #236.
As a secondary change, this PR also contains some refactor to the download code.