### PR TITLE
Fix "ANSI colors in Make Help command are not being interpreted"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,11 @@ test: ## Quick test using 3 batches
 
 help: ## Print help messages
 	@echo -e "$$(grep -hE '^\S*(:.*)?##' $(MAKEFILE_LIST) \
-		| sed -e 's/:.*##\s*/:/' -e 's/^\(.*\):\(.*\)/\\x1b[36m\1\\x1b[m:\2/' -e 's/^\([^#]\)/    \1/g'\
+		| sed \
+			-e 's/:.*##\s*/:/' \
+			-e 's/^\(.*\):\(.*\)/\\x1b[36m\1\\x1b[m:\2/' \
+			-e 's/^\([^#]\)/\1/g' \
+			-e 's/^\(#.*#\)/\\x1b[31m\1\\x1b[m/' \
 		| column -c2 -t -s : )"
 
 clean: ## Clean intermediate search files

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test: ## Quick test using 3 batches
 	fi
 
 help: ## Print help messages
-	@echo "$$(grep -hE '^\S*(:.*)?##' $(MAKEFILE_LIST) \
+	@echo -e "$$(grep -hE '^\S*(:.*)?##' $(MAKEFILE_LIST) \
 		| sed -e 's/:.*##\s*/:/' -e 's/^\(.\+\):\(.*\)/\\x1b[36m\1\\x1b[m:\2/' -e 's/^\([^#]\)/    \1/g'\
 		| column -c2 -t -s : )"
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test: ## Quick test using 3 batches
 
 help: ## Print help messages
 	@echo -e "$$(grep -hE '^\S*(:.*)?##' $(MAKEFILE_LIST) \
-		| sed -e 's/:.*##\s*/:/' -e 's/^\(.\+\):\(.*\)/\\x1b[36m\1\\x1b[m:\2/' -e 's/^\([^#]\)/    \1/g'\
+		| sed -e 's/:.*##\s*/:/' -e 's/^\(.*\):\(.*\)/\\x1b[36m\1\\x1b[m:\2/' -e 's/^\([^#]\)/    \1/g'\
 		| column -c2 -t -s : )"
 
 clean: ## Clean intermediate search files


### PR DESCRIPTION
The ```echo``` command do not interpret backslash escapes by default and thus do not allow the visualization of colors on the terminal. The interpretation can be enabled by adding  the parameter ```-e``` to the command.
Closes #248 